### PR TITLE
[#4] 멤버 엔티티 및 레포지토리 개발 

### DIFF
--- a/supermarket-api-gateway/src/main/java/com/harmony/supermarketapigateway/auth/entity/Member.java
+++ b/supermarket-api-gateway/src/main/java/com/harmony/supermarketapigateway/auth/entity/Member.java
@@ -1,0 +1,21 @@
+package com.supermarket.gateway.auth.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Entity
+@Getter
+public class Member {
+    @Id
+    private String memberId;
+    private String password;
+
+    protected Member() {};
+
+    public static Member createWithEncodedPassword(final String memberId, final String encodedPassword) {
+        return new Member(memberId, encodedPassword);
+    }
+}

--- a/supermarket-api-gateway/src/main/java/com/harmony/supermarketapigateway/auth/repository/MemberRepository.java
+++ b/supermarket-api-gateway/src/main/java/com/harmony/supermarketapigateway/auth/repository/MemberRepository.java
@@ -1,0 +1,10 @@
+package com.supermarket.gateway.auth.repository;
+
+import com.supermarket.gateway.auth.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByMemberId(String memberId);
+}


### PR DESCRIPTION
# [PR TEMPLATE]

## a. 설명
> 가장 기본적인 요건 기준으로 사용자 권한 인가에 필요한 Member 엔티티와 MemberRepository 인터페이스 추가

## b. 작업 내용
> 멤버 엔티티 클래스 추가
- 사용자의 ID와 비밀번호 저장
- 단, 비밀번호는 암호화된 상태로 멤버 엔티티로 넘어옴 가정

<br>

> MemberRepository 인터페이스 추가
- Member 엔티티에 대한 기본적인 CRUD 연산을 간단하게 구현하기 위해 Spring Data JPA 적용
- memberId를 이용한 사용자 조회 기능 구현

<br>

## c. 작업 회고
> 로그인 과정에 해당 멤버를 조회하는 과정에 사용자 ID를 통해 조회하게 되는데, 순차적으로 증가하는 ID 값을 사용하지 않고 이렇게 직접 문자열을 사용하는게 성능상에 문제가 없는지 확신이 없는 상태이다. 예상되는 문제는 아래와 같다.
```
(1) mysql에서는 PK에 필수적으로 클러스터리드 인덱싱이 걸리기에 매번 문자열의 순서를 비교해 재정리 하는 비용이 발생한다.
(2) 문자열 타입의 PK거 정수형 PK에 비해 메모리에 부하를 줄 수 있다.
```

<br>

## d. 기타 사항
> Member 엔티티와 관련된 추가적인 속성(예: 이메일, 전화번호 등)등의 사용자 관리 기능의 확장은 차후 고려 예정
```
2024-03-11 (프로젝트 멘토링 2주차) 기준, 개발 속도가 늦어 빠르게 상품 도메인 개발을 진행하고자 최소한의 요건으로 개발. 테스트 코드만 추가 할 예정
```
