### PR TITLE
[#5] API GATEWAY 서버에 멤버 등록 기능 구현 및 Valid를 이용한 DTO 검증

### DIFF
--- a/supermarket-api-gateway/src/main/java/com/harmony/supermarketapigateway/auth/controller/MemberRegistrationController.java
+++ b/supermarket-api-gateway/src/main/java/com/harmony/supermarketapigateway/auth/controller/MemberRegistrationController.java
@@ -1,0 +1,25 @@
+package com.supermarket.gateway.auth.controller;
+
+import com.supermarket.gateway.auth.dto.MemberRegistrationRequestDTO;
+import com.supermarket.gateway.auth.service.MemberRegistrationService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/register")
+public class MemberRegistrationController {
+    private final MemberRegistrationService memberRegistrationService;
+
+    @PostMapping()
+    public ResponseEntity<String> registerUser(@Valid @RequestBody final MemberRegistrationRequestDTO memberRegistrationRequestDTO) {
+        memberRegistrationService.registerMember(memberRegistrationRequestDTO);
+
+        return ResponseEntity.ok("회원가입 성공");
+    }
+}

--- a/supermarket-api-gateway/src/main/java/com/harmony/supermarketapigateway/auth/dto/MemberRegistrationRequestDTO.java
+++ b/supermarket-api-gateway/src/main/java/com/harmony/supermarketapigateway/auth/dto/MemberRegistrationRequestDTO.java
@@ -1,0 +1,19 @@
+package com.supermarket.gateway.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class MemberRegistrationRequestDTO {
+    @NotBlank(message = "회원 ID는 필수입니다.")
+    private final String memberId;
+    @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
+    private final String password;
+
+    public MemberRegistrationRequestDTO(@JsonProperty("memberId") String memberId, @JsonProperty("password") String password) {
+        this.memberId = memberId;
+        this.password = password;
+    }
+}

--- a/supermarket-api-gateway/src/main/java/com/harmony/supermarketapigateway/auth/service/MemberRegistrationService.java
+++ b/supermarket-api-gateway/src/main/java/com/harmony/supermarketapigateway/auth/service/MemberRegistrationService.java
@@ -1,0 +1,32 @@
+package com.supermarket.gateway.auth.service;
+
+import com.supermarket.gateway.auth.dto.MemberRegistrationRequestDTO;
+import com.supermarket.gateway.auth.entity.Member;
+import com.supermarket.gateway.auth.repository.MemberRepository;
+import com.supermarket.gateway.auth.exception.ErrorCode.AuthErrorCode;
+import com.supermarket.gateway.auth.exception.SupermarketAuthException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Service
+public class MemberRegistrationService {
+    private final PasswordEncoder passwordEncoder;
+    private final MemberRepository memberRepository;
+
+    public Member registerMember(final MemberRegistrationRequestDTO memberRegistrationRequestDTO) {
+        Optional<Member> existingMember = memberRepository.findByMemberId(memberRegistrationRequestDTO.getMemberId());
+        if (existingMember.isPresent()) {
+            throw new SupermarketAuthException(
+                    AuthErrorCode.DUPLICATE_MEMBER_ID.getCode(),
+                    AuthErrorCode.DUPLICATE_MEMBER_ID.getMessage()
+            );
+        }
+
+        Member newMember = Member.createWithEncodedPassword(memberRegistrationRequestDTO.getMemberId(), passwordEncoder.encode(memberRegistrationRequestDTO.getPassword()));
+        return memberRepository.save(newMember);
+    }
+}


### PR DESCRIPTION
# [PR TEMPLATE]

## a. 설명
> 사용자 회원가입 기능을 위한 컨트롤러와 DTO 그리고 서비스를 추가. 검증을 위해 `jakarata.validation.Valid` 적용

## b. 작업 내용
> MemberRegistrationRequestDTO 추가
- 회원가입시 요청되는 `데이터 구조`와 `검증 로직`을 담당하는 클래스

<br>

> MemberRegistrationService 구현
- 회원가입 로직 처리하는 서비스
- 멤버 엔티티에서 직접 암호화 작업을 하지 않게 `여기서 비밀번호 암호화`가 이루어짐
- `이미 존재하는 회원 ID에 대해 예외` 처리

<br>

> MemberRegistrationController 구현
- /register 경로에 대한 회원가입 요청을 처리하는 컨트롤러
- 요청이 성공적으로 처리되면 "회원가입 성공" 메시지를 반환

<br>

## c. 작업 회고
> DTO에 대한 유효성 검증 방식과 어디서 비밀번호를 암호화 해야하는지에 대한 고민
```
(1) DTO에 대한 유효성 검증을 어떤식으로 해야할지 고민을 했었다. 현재는 코드가 적어 컨트롤러에서 직접 하는게 더 효과적일거라고 생각했으나 DTO가 많아지게 될 경우 어차피 필요한 기능이라고 생각해 Valid를 적용했다. 

(2) 비밀번호를 암호화 하는 것도 멤버 엔티티의 역할인 것 같다고 생각했으나 애초에 멤버 엔터티는 빈이 아니기 때문에 의존성 주입을 받는
과정도 불가능했는데 그렇다고 빈으로 등록하자니 그래도 되는지에 대한 확신이 없었다. 또 향후 테스트를 할 때 굳이 의존성을 주입해야 하는 이유를 만들 필요가 없다고 생각해 서비스에서 주입토록 했다.
```

<br>

## d. 기타 사항
> 멤버 엔티티에 대한 테스트코드 작성 필요
