### PR TITLE
[#14] Member 클래스의 Getter에 의한 고객 비밀번호 노출 문제 해결 1차 시도

### DIFF
--- a/supermarket-api-gateway/src/main/java/com/harmony/supermarketapigateway/auth/entity/Member.java
+++ b/supermarket-api-gateway/src/main/java/com/harmony/supermarketapigateway/auth/entity/Member.java
@@ -1,13 +1,14 @@
-package com.supermarket.gateway.auth.entity;
+package com.harmony.supermarketapigateway.auth.entity;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import lombok.AllArgsConstructor;
-import lombok.Getter;
+import org.springframework.security.core.userdetails.User;
+
+import java.util.ArrayList;
 
 @AllArgsConstructor
 @Entity
-@Getter
 public class Member {
     @Id
     private String memberId;
@@ -17,5 +18,9 @@ public class Member {
 
     public static Member createWithEncodedPassword(final String memberId, final String encodedPassword) {
         return new Member(memberId, encodedPassword);
+    }
+
+    public User toUserDetails(){
+        return new User(this.memberId, this.password, new ArrayList<>());
     }
 }

--- a/supermarket-api-gateway/src/main/java/com/harmony/supermarketapigateway/auth/security/SupermarketUserDetailsService.java
+++ b/supermarket-api-gateway/src/main/java/com/harmony/supermarketapigateway/auth/security/SupermarketUserDetailsService.java
@@ -1,18 +1,15 @@
-package com.supermarket.gateway.auth.security;
+package com.harmony.supermarketapigateway.auth.security;
 
-import com.supermarket.gateway.auth.entity.Member;
-import com.supermarket.gateway.auth.exception.ErrorCode.AuthErrorCode;
-import com.supermarket.gateway.auth.exception.SupermarketAuthException;
-import com.supermarket.gateway.auth.repository.MemberRepository;
+import com.harmony.supermarketapigateway.auth.entity.Member;
+import com.harmony.supermarketapigateway.auth.repository.MemberRepository;
+import com.harmony.supermarketapigateway.exception.ErrorCode.AuthErrorCode;
+import com.harmony.supermarketapigateway.exception.SupermarketAuthException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
-
-import java.util.ArrayList;
 
 @RequiredArgsConstructor
 @Service
@@ -28,7 +25,7 @@ public class SupermarketUserDetailsService implements UserDetailsService {
                             AuthErrorCode.USER_NOT_FOUND.getCode(),
                             AuthErrorCode.USER_NOT_FOUND.getMessage()
                     ));
-            return new User(findMember.getMemberId(), findMember.getPassword(), new ArrayList<>());
+            return findMember.toUserDetails();
         } catch (SupermarketAuthException e) {
             log.error("Authentication error for memberId: {}. Error code: {}", memberId, e.getErrorCode());
             throw e;

--- a/supermarket-api-gateway/src/test/java/com/harmony/supermarketapigateway/auth/entity/MemberTest.java
+++ b/supermarket-api-gateway/src/test/java/com/harmony/supermarketapigateway/auth/entity/MemberTest.java
@@ -1,0 +1,29 @@
+package com.harmony.supermarketapigateway.auth.entity;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MemberTest {
+    @Nested
+    class 멤버_객체에_대한_보안성_체크 {
+        private String memberIdForSecurityTest = "hyeok";
+        private String passwordForSecurityTest = "암호화된 비밀번호";
+
+        /**
+         * Member의 getter()를 통해 비밀번호에 접근하는 것은 막았으나, 이렇게 해도 결국 멤버를 통해 받은 UserDetails를 통해한 비밀번호 유출은 막을 수 없다.
+         */
+        @Test
+        void getter와_toString에_의한_비밀번호_노출_된다(){
+            // given
+            Member targetMember = Member.createWithEncodedPassword(memberIdForSecurityTest, passwordForSecurityTest);
+
+            // when
+            String exportPassword = targetMember.toUserDetails().getPassword();
+
+            // then
+            assertEquals(passwordForSecurityTest, exportPassword);
+        }
+    }
+}

--- a/supermarket-api-gateway/src/test/java/com/harmony/supermarketapigateway/auth/entity/MemberTest.java
+++ b/supermarket-api-gateway/src/test/java/com/harmony/supermarketapigateway/auth/entity/MemberTest.java
@@ -1,5 +1,6 @@
 package com.harmony.supermarketapigateway.auth.entity;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -7,23 +8,25 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class MemberTest {
     @Nested
-    class 멤버_객체에_대한_보안성_체크 {
+    @DisplayName("멤버에 대한 보안성 체크")
+    class MemberSecurityCheck {
         private String memberIdForSecurityTest = "hyeok";
         private String passwordForSecurityTest = "암호화된 비밀번호";
 
         /**
-         * Member의 getter()를 통해 비밀번호에 접근하는 것은 막았으나, 이렇게 해도 결국 멤버를 통해 받은 UserDetails를 통해한 비밀번호 유출은 막을 수 없다.
-         */
+         * 취약점 기록: member에 대한 getter를 없애 고객 정보를 직접 조회할 순 없게됬지만 인증 과정을 위해 추출
+         **/
         @Test
-        void getter와_toString에_의한_비밀번호_노출_된다(){
+        @DisplayName("취약점 존재: member를 통해 얻을 수 있는 userDetails를 통해 여전히 유저 정보를 조회 가능")
+        void testUserDetailsExposePassword(){
             // given
             Member targetMember = Member.createWithEncodedPassword(memberIdForSecurityTest, passwordForSecurityTest);
 
             // when
-            String exportPassword = targetMember.toUserDetails().getPassword();
+            String exportedPassword = targetMember.toUserDetails().getPassword();
 
             // then
-            assertEquals(passwordForSecurityTest, exportPassword);
+            assertEquals(passwordForSecurityTest, exportedPassword);
         }
     }
 }


### PR DESCRIPTION
## a. 설명
> [#14] 이슈 해소를 위해 Member 클래스에 `@Getter`를 제거함. 이로인해 `member.getpassword()` 을 사용하던 `SupermarketUserDetailsService`에서 로그인시 인증/인가를 위해 필요한 `userdetails.UserDetails`을 내려주지 못하게됬는데 이 문제를 해결하기 위해 Member 객체에서 `userdetails.UserDetails`를 내려주는 방식을 적용해 getter 없이도 기존 로직이 동작토록 함.

## b. 작업 내용
> 1. Member 클래스에 `@Getter` 제거
```
비밀번호 및 고객ID 조회 이슈를 막기 위해 @Getter 자체를 제거
```

> 2. SupermarketUserDetailsService에서 인증 절차를 위해 필요했던 `userdetails.UserDetails`를 내려주는 역할을 member에게 양도
```
멤버에서 userdetails.UserDetails를 상속받는 User 객체를 직접 만들어 내려주는 toUserDetails() 작성
```

> 3. Member의 비밀번호 조회를 위한 2차 보안성 검토
```
멤버로 부터 전달받은 User 객체를 통해 멤버의 비밀번호를 조회가능한 취약점 발견 및 이를 문서화하기 위한 테스트 코드 작성
```
<img width="430" alt="유저도 결국 " src="https://github.com/f-lab-edu/super-market/assets/68278903/1134cbdb-ce03-4dd9-a310-229fb709b6e8">

## c. 작업 회고
> 쉽게 해결할 수 있는 문제인 줄 알았는데 생각보다 쉽지 않았다. 추가적으로 발생한 User의 getPassword에 의한 비밀번호 조회 문제는 `userdetails.User`를 상속받는 클래스를 만들고 `getPassword()` 부분만 재정의 하고 확인해볼까 싶었는데 스프링 시큐리티의 동작 방식에 대해 잘 이해하지 못한 상태에서 이런 접근 방식은 의미가 없을 거 같아 일단 멤버 클래스를 통해 직접 조회하는 걸 막는 부분까지만 진행했다.

## d. 기타 사항
> [#12]의 이슈에 대한 PR 전이어서 어쩔 수 없이 패키지 명 수정을 같이 해주었습니다. 읽으시는데 번거로움 만들어 죄송합니다!