### PR TITLE
[#21] PRODUCT 도메인 개발 및 유닛 테스트 작성

### DIFF
--- a/supermarket-api-product/src/main/java/com/harmony/supermarketapiproduct/domain/Product.java
+++ b/supermarket-api-product/src/main/java/com/harmony/supermarketapiproduct/domain/Product.java
@@ -1,0 +1,47 @@
+package com.harmony.supermarketapiproduct.domain;
+
+
+import com.harmony.supermarketapiproduct.application.dto.ProductDto;
+import com.harmony.supermarketapiproduct.common.exception.ProductInsufficientStockException;
+import com.harmony.supermarketapiproduct.common.exception.ProductQuantityNegativeException;
+import com.harmony.supermarketapiproduct.common.exception.ProductStockMismatchException;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "product")
+public class Product {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long productId;
+
+    private String name;
+
+    private Long price;
+
+    private Integer stockQuantity;
+
+    @Version
+    private Long version;
+
+    public Product(final String name, final Long price, final Integer stockQuantity){
+        this.name = name;
+        this.price = price;
+        this.stockQuantity = stockQuantity;
+    }
+
+    public ProductDto toProductDto(){ return new ProductDto(this.productId, this.name, this.price, this.stockQuantity); }
+
+    public void decreaseStock(final Integer quantity){
+        if (quantity < 0) { throw new ProductQuantityNegativeException(); }
+        if (this.stockQuantity < quantity){ throw new ProductInsufficientStockException(); }
+
+        this.stockQuantity -= quantity;
+    }
+
+    public void verifyStockAmount(final Integer expectedStock){
+        if (!this.stockQuantity.equals(expectedStock)) { throw new ProductStockMismatchException(); }
+    }
+}

--- a/supermarket-api-product/src/test/java/com/harmony/supermarketapiproduct/domain/ProductTest.java
+++ b/supermarket-api-product/src/test/java/com/harmony/supermarketapiproduct/domain/ProductTest.java
@@ -1,0 +1,55 @@
+package com.harmony.supermarketapiproduct.domain;
+
+import com.harmony.supermarketapiproduct.common.exception.ProductInsufficientStockException;
+import com.harmony.supermarketapiproduct.common.exception.ProductQuantityNegativeException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ProductTest {
+    @DisplayName("성공 테스트")
+    @Nested
+    class SuccessTest{
+        @DisplayName("재고 감소 성공 로직 테스트 정상")
+        @Test
+        void decreaseStockSuccess() {
+            // given
+            Product product = new Product("레예스 글러브", 3000L, 3);
+
+            // when
+            product.decreaseStock(2);
+
+            // then
+            Integer expectedStockQuantity = 1;
+            assertDoesNotThrow(() -> product.verifyStockAmount(expectedStockQuantity));
+        }
+    }
+
+    @DisplayName("실패 테스트")
+    @Nested
+    class FailTest{
+        @DisplayName("재고 감소의 결과가 재고를 0 미만으로 만들 경우 예외 발생")
+        @Test
+        void decreaseStockBelowZeroThrowsException(){
+            // given
+            Product soldoutProduct = new Product("레예스 글러브", 3000L, 0);
+            Product noSoldoutProduct = new Product("레예스 글러브", 3000L, 3);
+
+            // when & then
+            assertThrows(ProductInsufficientStockException.class, () -> soldoutProduct.decreaseStock(1));
+            assertThrows(ProductInsufficientStockException.class, () -> noSoldoutProduct.decreaseStock(10));
+        }
+
+        @DisplayName("재고 감소 수량은 음수 미허용")
+        @Test
+        void decreaseStockWithNegativeValues_ThrowException() {
+            // given
+            Product product = new Product("레예스 글러브", 3000L, 0);
+
+            // when & then
+            assertThrows(ProductQuantityNegativeException.class, () -> product.decreaseStock(-1));
+        }
+    }
+}


### PR DESCRIPTION
## a. 설명
> [#21] 이슈를 위해 `상품 재고 감소` 역할을 수행할 PRODUCT 도메인을 개발했다. 테스트 케이스등에 필요한 재고 확인 기능을 지원키 위해 verfiyStockAmount() 메서드를 구현했으며 여러 인스턴스를 사용하는 환경에서의 동시성 이슈를 막기 위해 `@Version` 애노테이션을 이용해 낙관적 락을 적용했다.

## b. 작업 내용
> 상품 재고 감소를 위한 메서드 개발 및 테스트 코드를 작성했다.

[개발 내용]
- 상품 재고 감소를 위한 decreaseStock() 메서드 작성
```
(1) 감소할 수량이 음수로 들어온 경우 ProductQuantityNegativeException() 발생
(2) 감소할 양이 현재 재고보다 작은 경우 ProductInsufficientStockException() 발생
(3) 위 [1, 2]의 검증을 통과한 경우 재고 감소 처리 (단, 해당 도메인을 관리하는 서비스에서 예외 발생시 해당 내용들 롤백이 일어날 수 있다.)
```
- 상품 재고 값이 예상한 값과 같은지 비교 하기 위한 verifyStockAmount() 메서드 개발
```
(1) getter를 통해 재고 정보를 노출시키지 않더라도 성공 테스트 (decreaseStockSuccess())를 수행하기 위해 작성했다.
```
- ProductDto 로 변환을 위한 toProductDto() 메서드 개발
```
(1) getter를 통한 상품 정보 노출을 하지 않더라도 해당 상품에 대한 ProductDto를 만들기 위해 필요한 메서드이다.
(2) 서비스 클래스에서 Product를 dto로 변환하는 로직을 처리하지 않아도 되서 서비스 클래스의 크기를 줄일 수 있었다.
```

[테스트 케이스]
- 성공 케이스: 재고 감소 해피 케이스
- 실패 케이스(1): 재고 감소의 결과가 재고를 0 미만 으로 만들 경우 예외 발생 케이스
- 실패 케이스(2): 재고 감소 요청 으로 넘어온 재고 감소 수량이 음수인 경우 예외 발생 케이스

## c. 작업 회고
> 서비스 클래스에서 도메인을 분리해본 소감
```
결론만 말하자면 긴가민가 하고 도메인을 분리해봤는데, 생각보다 많은 이익이 있는 거 같다.

서비스 클래스에서는 
(1) 다중 인스턴스에서의 동시 접근을 막기위해 설정해둔 낙관적 락으로 인한 예외가 발생했을 때의 처리와
(2) 하나의 트랜잭션에서의 여러 상품에 대한  재고 감소시 `재시도` 기능을 지원하는 등

생각보다 코드가 복잡했는데, 재고 감소 가능 여부등의 유효성 체크나 실제 재고 감소 로직을 따로 분리하는 것
만으로도 코드의 복잡성이 많이 줄어들었다. 또 테스트 코드를 작성할 때도 명료하게 작성할 수 있었다.
```

> 낙관적 락을 적용한 이유
```
사실 정확한 근거를 제시하기 어렵다. 낙관적 락이 지금 로직에 더 효과적인지에 대한 근거를 제시하려면
락에 대한 비용 뿐 아니라 I/O, 캐시, 컨텍스트 스위칭등 굉장히 복잡한 개념들에 대한 깊은 고민 후에 답변
을 낼 수 있을 거 같다는 느낌이 들었기 때문이다. 

그래서 지금은 '비교적 가벼운 낙관적 락을 적용해 보고 향후 더 높은 안전성이 필요해지면 다른 방법을
고민해보기로 했다.`
```

> 나는 왜 이렇게 getter를 배척했을까
```
지난번에 member 클래스를 개발하다 보니 해당 엔터티에 대한 정보 유출을 막아야 한다는 생각이 기저에 깔려
있었던 거 같다. 지금 생각해보면 굳이 상품 정보를 노출시키지 말아야 할 이유는 없어보인다.
```

## d. 기타 사항
> 상품 도메인에 대한 테스트 코드 부족, 나중에라도 낙관적 락을 적용할 근거 더 명확히 고민해보기
