### PR TITLE
[#22] 상품 재고 감소 과정에서 발생할 수 있는 원자성, 동시성 문제 핸들링

### DIFF
--- a/supermarket-api-product/src/main/java/com/harmony/supermarketapiproduct/product/application/ProductService.java
+++ b/supermarket-api-product/src/main/java/com/harmony/supermarketapiproduct/product/application/ProductService.java
@@ -1,0 +1,61 @@
+package com.harmony.supermarketapiproduct.product.application;
+
+
+import com.harmony.supermarketapiproduct.product.application.dto.ProductDto;
+import com.harmony.supermarketapiproduct.product.application.dto.StockDecreaseDto;
+import com.harmony.supermarketapiproduct.product.common.exception.ProductNotFoundException;
+import com.harmony.supermarketapiproduct.product.common.exception.ProductStockUpdateException;
+import com.harmony.supermarketapiproduct.product.domain.Product;
+import com.harmony.supermarketapiproduct.product.domain.ProductRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ProductService {
+    private final ProductRepository productRepository;
+
+    @Transactional
+    public List<ProductDto> decreaseStock(final List<StockDecreaseDto> stockDecreaseDtos) throws ObjectOptimisticLockingFailureException {
+        List<ProductDto> productDtoList = new ArrayList<>();
+
+        for (StockDecreaseDto stockDecreaseDto: stockDecreaseDtos){
+            boolean success = false;
+            int attempts = 0;
+
+            while(!success) {
+                try {
+                    Product product = productRepository.findById(stockDecreaseDto.getProductId())
+                            .orElseThrow(() -> {
+                                log.info("Product not found: " + stockDecreaseDto.getProductId());
+                                return new ProductNotFoundException();
+                            });
+
+                    product.decreaseStock(stockDecreaseDto.getQuantity());
+                    productRepository.save(product);
+                    productDtoList.add(product.toProductDto());
+                    success = true;
+                } catch (ObjectOptimisticLockingFailureException e){
+                    attempts ++;
+                    if (attempts >= 3 ) {
+                        log.error("Failed to decrease stock after " + attempts + " attempts for product ID " + stockDecreaseDto.getProductId(), e);
+                        throw new ProductStockUpdateException();
+                    }
+                    try {
+                        Thread.sleep(100);
+                    } catch (InterruptedException ie){
+                        Thread.currentThread().interrupt();
+                    }
+                }
+            }
+        }
+        return productDtoList;
+    }
+}

--- a/supermarket-api-product/src/main/java/com/harmony/supermarketapiproduct/product/application/ProductService.java
+++ b/supermarket-api-product/src/main/java/com/harmony/supermarketapiproduct/product/application/ProductService.java
@@ -49,11 +49,6 @@ public class ProductService {
                         log.error("Failed to decrease stock after " + attempts + " attempts for product ID " + stockDecreaseDto.getProductId(), e);
                         throw new ProductStockUpdateException();
                     }
-                    try {
-                        Thread.sleep(100);
-                    } catch (InterruptedException ie){
-                        Thread.currentThread().interrupt();
-                    }
                 }
             }
         }

--- a/supermarket-api-product/src/main/java/com/harmony/supermarketapiproduct/product/application/ProductService.java
+++ b/supermarket-api-product/src/main/java/com/harmony/supermarketapiproduct/product/application/ProductService.java
@@ -24,7 +24,7 @@ public class ProductService {
     private final long MAX_RETRY_ATTEMPTS = 3;
 
     @Transactional
-    public List<ProductDto> decreaseStock(final List<StockDecreaseDto> stockDecreaseDtos) throws ObjectOptimisticLockingFailureException {
+    public List<ProductDto> decreaseStock(final List<StockDecreaseDto> stockDecreaseDtos) {
         List<ProductDto> productDtoList = new ArrayList<>();
 
         for (StockDecreaseDto stockDecreaseDto: stockDecreaseDtos){

--- a/supermarket-api-product/src/test/java/com/harmony/supermarketapiproduct/concurrency/ProductServiceConcurrencyTest.java
+++ b/supermarket-api-product/src/test/java/com/harmony/supermarketapiproduct/concurrency/ProductServiceConcurrencyTest.java
@@ -1,21 +1,9 @@
 package com.harmony.supermarketapiproduct.concurrency;
 
 import com.harmony.supermarketapiproduct.product.application.ProductService;
-import com.harmony.supermarketapiproduct.product.application.dto.StockDecreaseDto;
-import com.harmony.supermarketapiproduct.product.domain.Product;
 import com.harmony.supermarketapiproduct.product.domain.ProductRepository;
-import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.orm.ObjectOptimisticLockingFailureException;
-
-import java.util.List;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SpringBootTest
 public class ProductServiceConcurrencyTest {
@@ -26,32 +14,4 @@ public class ProductServiceConcurrencyTest {
     @Autowired
     private ProductRepository productRepository;
 
-    @Test
-    void testOptimisticLockingOnConcurrentStockDecrease() throws InterruptedException {
-        // given
-        final Long productId = 1L;
-        productRepository.save(new Product("레예스 글러브", 100000L, 10));
-        final CountDownLatch latch = new CountDownLatch(2);
-        final AtomicBoolean optimisticLockExceptionCaught = new AtomicBoolean(false);
-        ExecutorService executor = Executors.newFixedThreadPool(2);
-
-        // when
-        Runnable decreaseStockTask = () -> {
-            try {
-                productService.decreaseStock(List.of(new StockDecreaseDto(productId, 1)));
-            } catch (ObjectOptimisticLockingFailureException e) {
-                optimisticLockExceptionCaught.set(true);
-            } finally {
-                latch.countDown();
-            }
-        };
-
-        executor.execute(decreaseStockTask);
-        executor.execute(decreaseStockTask);
-        latch.await();
-        executor.shutdown();
-
-        // Then
-        assertTrue(optimisticLockExceptionCaught.get(), "An OptimisticLockException should have been thrown due to concurrent modifications.");
-    }
 }

--- a/supermarket-api-product/src/test/java/com/harmony/supermarketapiproduct/concurrency/ProductServiceConcurrencyTest.java
+++ b/supermarket-api-product/src/test/java/com/harmony/supermarketapiproduct/concurrency/ProductServiceConcurrencyTest.java
@@ -1,0 +1,57 @@
+package com.harmony.supermarketapiproduct.concurrency;
+
+import com.harmony.supermarketapiproduct.product.application.ProductService;
+import com.harmony.supermarketapiproduct.product.application.dto.StockDecreaseDto;
+import com.harmony.supermarketapiproduct.product.domain.Product;
+import com.harmony.supermarketapiproduct.product.domain.ProductRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+public class ProductServiceConcurrencyTest {
+
+    @Autowired
+    private ProductService productService;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Test
+    void testOptimisticLockingOnConcurrentStockDecrease() throws InterruptedException {
+        // given
+        final Long productId = 1L;
+        productRepository.save(new Product("레예스 글러브", 100000L, 10));
+        final CountDownLatch latch = new CountDownLatch(2);
+        final AtomicBoolean optimisticLockExceptionCaught = new AtomicBoolean(false);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+
+        // when
+        Runnable decreaseStockTask = () -> {
+            try {
+                productService.decreaseStock(List.of(new StockDecreaseDto(productId, 1)));
+            } catch (ObjectOptimisticLockingFailureException e) {
+                optimisticLockExceptionCaught.set(true);
+            } finally {
+                latch.countDown();
+            }
+        };
+
+        executor.execute(decreaseStockTask);
+        executor.execute(decreaseStockTask);
+        latch.await();
+        executor.shutdown();
+
+        // Then
+        assertTrue(optimisticLockExceptionCaught.get(), "An OptimisticLockException should have been thrown due to concurrent modifications.");
+    }
+}


### PR DESCRIPTION
## a. 설명
> 상품 재고 감소 과정에서 발생할 수 있는 `여러 상품에 대한 재고 감소시 실패의 경우 롤백 처리` 문제와 `여러 인스턴스에서 동시에 특정 상품 을 조회 후 수정 한 경우`에 대한 동시성 이슈를 `낙관적 락`을 이용해 해소

## b. 작업 내용
> `원자성 문제` 해결을 위한 `트랜잭션 적용`과 `분산 처리 환경에서의 동시성 문제 해결`을 위한 `낙관적 락`의 적용

[작업 내용]
- 여러개의 재고 감소가 하나의 작업으로서 이루어지는 경우 원자성 보장토록 개발
- 동시성 문제 발생시에도 최대 3회까지 재시도 (동시성 문제는 Product 엔터티에 Version 필드를 정의해 낙관적 락 적용해 해결)

[테스트 케이스]
- 실패 케이스(1): 거의 동시에 두 스레드에서 재고 감소를 시도할 경우 낙관적 락에 의한 OptimisticLockException 발생


## c. 작업 회고
> 깊은 고민보단 빠른 결정
```
비관적 락 외에도 여러 해결책들이 있는 거 같았는데, 명확한 의사결정을 하기엔 아직 이해해야 할 것들이 많아 일단 빠르게 개발하고 차후 필요시 개선해보기로 했다.
```

## d. 기타 사항
> 낙관적 락에 대한 테스트 코드를 짜는데 어려움이 있어 구색만 맞췄다. 이 부분에 대해서 시간이 날 때 제대로 고민해보면 좋을 거 같다.
