### PR TITLE
[#27] Mapper를 적용해 `Product`기반의 `ProductDto` 생성 기능 제공

### DIFF
--- a/supermarket-api-product/src/main/java/com/harmony/supermarketapiproduct/application/dto/ProductDto.java
+++ b/supermarket-api-product/src/main/java/com/harmony/supermarketapiproduct/application/dto/ProductDto.java
@@ -1,0 +1,11 @@
+package com.harmony.supermarketapiproduct.application.dto;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public class ProductDto {
+    private Long id;
+    private String name;
+    private Long price;
+    private Integer quantityStock;
+}

--- a/supermarket-api-product/src/main/java/com/harmony/supermarketapiproduct/application/mapper/ProductMapper.java
+++ b/supermarket-api-product/src/main/java/com/harmony/supermarketapiproduct/application/mapper/ProductMapper.java
@@ -1,0 +1,16 @@
+package com.harmony.supermarketapiproduct.application.mapper;
+
+import com.harmony.supermarketapiproduct.application.dto.ProductDto;
+import com.harmony.supermarketapiproduct.domain.Product;
+
+public class ProductMapper {
+
+    public static ProductDto toDecreaseProductDto(Product decreasedProduct){
+        if (decreasedProduct == null) {
+            return null;
+        }
+
+        return new ProductDto(decreasedProduct.getProductId(), decreasedProduct.getName(), decreasedProduct.getPrice(), decreasedProduct.getStockQuantity());
+    }
+
+}

--- a/supermarket-api-product/src/main/java/com/harmony/supermarketapiproduct/domain/Product.java
+++ b/supermarket-api-product/src/main/java/com/harmony/supermarketapiproduct/domain/Product.java
@@ -1,14 +1,16 @@
 package com.harmony.supermarketapiproduct.domain;
 
-import com.harmony.supermarketapiproduct.application.dto.ProductDto;
+
 import com.harmony.supermarketapiproduct.common.exception.ProductInsufficientStockException;
 import com.harmony.supermarketapiproduct.common.exception.ProductQuantityNegativeException;
 import com.harmony.supermarketapiproduct.common.exception.ProductStockMismatchException;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "product")
 public class Product {
@@ -31,8 +33,6 @@ public class Product {
         this.stockQuantity = stockQuantity;
     }
 
-    public ProductDto toProductDto(){ return new ProductDto(this.productId, this.name, this.price, this.stockQuantity); }
-
     public void decreaseStock(final Integer quantity){
         if (quantity < 0) { throw new ProductQuantityNegativeException(); }
         if (this.stockQuantity < quantity){ throw new ProductInsufficientStockException(); }
@@ -43,4 +43,5 @@ public class Product {
     public void verifyStockAmount(final Integer expectedStock){
         if (!this.stockQuantity.equals(expectedStock)) { throw new ProductStockMismatchException(); }
     }
+
 }


### PR DESCRIPTION
## a. 설명
> 🎇Dto 객체 생성 책임을 Mapper에 인가

Product 클래스가 `toProductDto()`를 통해 직접 dto 객체 생성을 지원하는 것에 대해 OCP를 위반한다는 문제사항이 [#27]로 올라와 `mapper`를 적용해 이를 해결

<br>

## b. 작업 내용
> 1. Product 클래스의 `toProductDto()` 제거 및 클래스 레벨의 `@Getter` 적용 

- Product에서 더 이상 Dto 생성하는 기능을 제공할 필요가 없어 `toProductDto()` 제거
- 객체 생성을 위해 외부에서 Product의 필드 조회를 할 수 있어야 하기에 `@Getter` 적용
- 다양한 필드에 대한 DTO들이 생성될 것으로 판단되 매퍼를 유연하게 다루기 위해 `@Getter`을 클래스 레벨로 적용

> 2. ProductDto 생성 및 두 클래스간의 매핑을 위한 Mapper 적용

- `assembler`, `converter` 등의 키워드를 찾아봤지만 mapper와 역할의 큰 차이가 없고 아직 명백한 차이를 이해하지 못해 가장 많은 레퍼런스가 있던 mapper로 적용
- `mapStruct`등의 외부 라이브러리는 당장 적용치 않고 보일러 코드가 큰 불편을 만들 때 즈음 적용키로함

<br>


## c. 작업 회고
> 1. 이슈 내용 분석

해당 이슈는 `Product에서 ProductDto를 생성하면 안된다.`라는 전제에 `동의를 해야만` 해결해야하는 문제로 간주할 수 있다. 그래서 `왜 Product에서 ProductDto를 생성하면 안되는지`에 대한 이유를 고민해봤다.

> 2. `ProductDto`가 변경되면 `Product`도 변경해야 하는 문제

```
@AllArgsConstructor
class ProductDto {
    private Long id;
    private String name;
    private Integer quantity;
}
```
```
class Product {
    ..
    public ProductDto toProductDto() {
         return new ProductDto(this.id, this.name, this.quantity);
    }
}
```
먼저 위 코드를 보면 `Product가 직접 ProductDto를 생성`하고 있다. 이 경우 `의존성을 가지게`되는데 이는 `ProductDto`의 이름이나 필드가 변경되면 `Product`도 변경해야 한다는 것을 의미한다. 그렇기 때문에 `도메인 클래스같이 중요한 클래스`가 변경 가능성이 높은 `ProductDto`같은 클래스에 의존하게 되면 `많은 코드변경`이 일어날 가능성이 높아지고 이는 유지보수 측면에서 좋지 않을 수 있다.

위와 같은 관점에 대해선 충분히 동의가 되어 `Product에서 직접 ProdcutDto를 생성치 않도록`하는 방법을 고민해보기로 했다.

<br>


> 3. mapper 적용시 얻을 수 있는 이점

<img src="https://github.com/f-lab-edu/super-market/assets/68278903/e1386690-525c-45b7-bfd8-ef0dcddb8385" height="240" width="500">

##### [그림1]. 의존관계

<br>

`mapper` 적용시 `더 이상 Product는 Dto 변환 관련해서 아무런 신경을 쓰지 않아도 된다.`라는 이점을 얻을 수 있다. 물론 mapper는 변환을 위한 두 클래스를 다 알아야해서  `오히려 dto 생성을 위해 필요한 의존성은 2개로 늘었기에` 이런 구성이 만들어낼 수 있는 문제들에 대해서도 고민해볼 필요가 있어 보인다.

<img src="https://github.com/f-lab-edu/super-market/assets/68278903/91aeff0b-6e70-4ba8-9a95-f5af711c4dec" height="240" width="500">

<img src="https://github.com/f-lab-edu/super-market/assets/68278903/6a016330-6405-4d93-8694-91d5233ead66" height="240" width="500">

##### [그림2]. 더 이상 서로를 몰라도 되는 `Product`와 `ProductDto`


<br> 

> 4. Product와 ProductDto는 추상화가 필요한가

위에서 말했듯이 mapper는 엔터티와 DTO 클래스에 의존성을 가진다. 의존성을 무조건 다 없애야 할까? 의존성을 없애기 위한 방법으론 DI가 떠오르는데 이를 위해서 Product와 ProductDto 추상화가 선행되어야 한다. 또 Component로 등록해야 하고 지금처럼 static method로 설정하지 않고 생성자 주입을 통해 mapper 클래스 생성 시점에 이 변환 작업이 일어나야하고, mapper 클래스 역시 추상화해야한다. `지금은 이런 복잡한 방법이 필요한 이유를 예단할 수 없어 더 고민치 않기로 했다.`


## d. 기타 사항
> 해결 안된 고민 

- Service에서 처리하는 방법도 왜 안되는건지 차후 더 고민해보기.
- Mapper를 사용하면 (1) Product가 수정되는 경우, (2) ProductDto가 수정되는 경우에 둘 다 Mapper를 수정해야 한다. 오히려 파일 수정에 대한 전체적인 영향도가 늘어난 셈이다. 이 경우와 같이 수정의 영향을 받는 정량적인 파일 개수가 늘어나는 것 보다 Product같은 중요 클래스의 변경이 줄어드는 것이 왜 더 나은 선택인지 아직 잘 이해가 안간다. 