### PR TITLE
[#28] 상품 재고 감소 기능 제공을 위한 API 개발

### DIFF
--- a/supermarket-api-product/src/main/java/com/harmony/supermarketapiproduct/application/dto/ProductDto.java
+++ b/supermarket-api-product/src/main/java/com/harmony/supermarketapiproduct/application/dto/ProductDto.java
@@ -1,7 +1,9 @@
 package com.harmony.supermarketapiproduct.application.dto;
 
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 
+@Getter
 @AllArgsConstructor
 public class ProductDto {
     private Long id;

--- a/supermarket-api-product/src/main/java/com/harmony/supermarketapiproduct/application/dto/StockDecreaseDto.java
+++ b/supermarket-api-product/src/main/java/com/harmony/supermarketapiproduct/application/dto/StockDecreaseDto.java
@@ -1,0 +1,18 @@
+package com.harmony.supermarketapiproduct.application.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class StockDecreaseDto {
+    @NotNull
+    private Long productId;
+
+    @NotNull @Min(1) @Max(100)
+    private Integer quantity;
+
+}

--- a/supermarket-api-product/src/main/java/com/harmony/supermarketapiproduct/controller/ProductController.java
+++ b/supermarket-api-product/src/main/java/com/harmony/supermarketapiproduct/controller/ProductController.java
@@ -1,10 +1,24 @@
 package com.harmony.supermarketapiproduct.controller;
 
+import com.harmony.supermarketapiproduct.application.ProductService;
+import com.harmony.supermarketapiproduct.application.dto.ProductDto;
+import com.harmony.supermarketapiproduct.application.dto.StockDecreaseDto;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
+@RequestMapping("/api/v1")
 @RequiredArgsConstructor
 public class ProductController {
+    private final ProductService productService;
+
+    @PatchMapping("/products/decrease-stock")
+    public List<ProductDto> decreaseStock(@Valid @RequestBody final List<StockDecreaseDto> stockDecreaseDtos) {
+
+        return productService.decreaseStock(stockDecreaseDtos);
+    }
 
 }


### PR DESCRIPTION
## a. 설명
> [#28] 해결을 위해 상품 재고 감소 기능 제공을 위한 API 개발과 데이터 전달을 위한 DTO 개발 및 검증 로직 적용

## b. 작업 내용
> 1. decreaseStock()를 통한 request mapping
- 요청을 처리할 decreaseStock 메서드 작성
- 유연한 컨트롤러 제공을 위한 버전정보 정의`/api/v1`
- 요청값에 대한 검증을 위해 `@Valid` 애노테이션 적용

> 2. 상품 재고 감소 요청을 위한 값 전달을 위한 StockDecreaseDto 생성
- 상품 재고 감소 요청값을 전달하는 데 필요한 `StockDecreaseDto` 클래스 작성
- 각 필드에 대한 제약사항을 validation에서 제공하는 애노테이션을 통해 정의함
- 직렬화 및 조회를 위해 `@getter` 적용
- 간편하게 객체를 생성하기 위해 `@AllArgsConstructor` 적용

> 3. ProductDto 직렬화를 위한 `@Getter`적용
- API Test 과정에서 직렬화를 위해 ProductDto의 `@Getter`가 필요함을 확인 해를 적용

> 4. 스웨거 문서 작성
[상품 재고 감소  API 명세(프로토타입)](https://app.swaggerhub.com/apis/cksgurwkd12/supermarket-product/supermaret-product-v1)

## c. 작업 회고
> 1. 읽기 자연스러운 request url
처음 도입하고 싶었던 url은 `/products/{productId}/decrease-stock`였다. 단순히 decrease-stock라는 표현보다 훨씬 해당 api의 역할에 대해 잘 표현하고 있다는 생각 때문이었다. 하지만 위 방법을 적용하려면 `(1) pathParam을 따로 받아줘야 하는 문제`와 `(2) 이런 값들을 dto로 합치는 과정이 번거롭다`는 문제를 감수해야했고 굳이 그럴 필요가 있나 라는 생각에 `/products/decrease-stock`라는 url을 적용하고 body로 요청 값들을 받아 다루기로 했다. 이런 방법은 `검증 처리를 묶어서`할 수 있고 `Dto로의 변환이 간결해진다`는 장점이 있음을 확인했다.

> 2. 직렬화를 위해 getter가 필요하구나 ..
당연한 소리지만 JSON으로의 직렬화를 위해선 DTO에 대한 조회가 필요하다는 사실을 이제서야 깨달았다. getter의 필요성을 분명히 느끼는 와중에도 `직렬화 로직이 DTO 안으로 들어간다면?` 같은 생각들이 자꾸 들었다. 왜 자꾸 getter에 집착하는지 모르겠지만 이제 그만 놓아줄 때가 된 거 같아 그만 질척거리고 마음을 정리하기로 했다.

> 3. `StockDecreaseDto`의 검증에 대해서
productId와 quantity 필드에 대한 검증 정책은 사실 요청하기 나름이라 일단 깊게 고민하지 않고 MIN, MAX, NOTNULL 등의 최소한의 검증만 진행키로 했다. 그런데 작업을 마치고 API TEST를 하는 과정에서 클라이언트는 `400 Status`를 받을 수 밖에 없다는 걸 깨달았고 이를 해결하려면 `BindingResult` 등을 이용해 메시지를 넣어주는 방법이 있음을 확인했지만 지금은 일단 개발의 복잡성을 줄이기 위해 별도 처리는 하지 않기로했다.


## d. 기타 사항
> 현재는 API Test를 이용해 컨트롤러 관련 로직을 테스트했는데, 컨트롤러에 대한 테스트가 필요한건지에 대한 확신이 없는 상태이다. 이 부분에 대해 차후 고민해보자.
