### PR TITLE
[#31] 로컬 환경에서 API TEST를 돕기 위한 sql 스크립트 초기화 설정 적용 및 로깅 설정

### DIFF
--- a/supermarket-api-product/src/main/resources/application.properties
+++ b/supermarket-api-product/src/main/resources/application.properties
@@ -1,1 +1,24 @@
-spring.application.name=supermarket-api-product
+spring.profiles.active=local
+
+# H2 데이터베이스 연결 설정
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.h2.console.enabled=true
+
+# JPA/Hibernate 설정
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.hibernate.ddl-auto=none
+spring.jpa.show-sql=true
+
+
+# SQL 스크립트 초기화 설정
+spring.sql.init.mode=always
+
+# 로깅 설정
+logging.level.root=INFO
+logging.level.org.springframework.web=INFO
+logging.level.org.hibernate=INFO
+logging.level.org.hibernate.SQL=DEBUG 
+logging.level.org.hibernate.type.descriptor.sql=trace 

--- a/supermarket-api-product/src/main/resources/data.sql
+++ b/supermarket-api-product/src/main/resources/data.sql
@@ -1,0 +1,8 @@
+INSERT INTO `product` (`name`, `price`, `stock_quantity`)
+VALUES ('레예스 글러브(빨강)', 300000, 5);
+
+INSERT INTO `product` (`name`, `price`, `stock_quantity`)
+VALUES ('팹시 콜라 제로 210ml(단품)', 300, 100);
+
+INSERT INTO `product` (`name`, `price`, `stock_quantity`)
+VALUES ('m16(구형)', 1000000, 15);

--- a/supermarket-api-product/src/main/resources/schema.sql
+++ b/supermarket-api-product/src/main/resources/schema.sql
@@ -1,0 +1,12 @@
+-- product 테이블이 이미 존재한다면 삭제
+DROP TABLE IF EXISTS `product`;
+
+-- product 테이블 생성
+CREATE TABLE `product` (
+                           `product_id` BIGINT NOT NULL AUTO_INCREMENT,
+                           `name` VARCHAR(255) NOT NULL,
+                           `price` BIGINT NOT NULL,
+                           `stock_quantity` INT NOT NULL,
+                           `version` BIGINT NOT NULL DEFAULT 0,
+                           PRIMARY KEY (`product_id`)
+);


### PR DESCRIPTION
## a. 설명
> [#31]을 해결하기 위해 테이블 생성을 위한 `schema.sql`과 더미 데이터 삽입을 위한 `data.sql`을 작성 후 àpplication.properties`의 `spring.sql.init.mode=always` 설정을 적용해 스프링 부트 프로젝트 실행시 자동으로 테스트용 데이터 세팅되도록함. 이 과정에서 필요한 로깅 설정도 함께 정의

## b. 작업 내용
> 1. application.propertes에 SQL 스크립트 초기화 설정 적용
- schema.sql을 통해 테이블을 생성하기에 ddl-auto 설정은 none으로
- spring.sql.init.mode를 always로 설정시 resource에 작성해둔 schema.sql과 data.sql이 실행됨을 확인

> 2. application.propertes에 sql 모니터링을 위한 로깅 설정 적용
- JPA가 변환하고 있는 쿼리들을 파악하기 위해 SQL=DEBUG, descriptor.sql=trace 설정 적용
- hibernate 설정을 DEBUG로 할 경우 관련 로그가 너무 많이 출력되 실행시 초기화되는 sql은 로깅하지 않기로
- hibernate 로깅 설정을 DEBUG로 할 시 프로젝트 초기 설정 관련 쿼리는 조회할 순 있으나 온갖 로그들이 다 출력되 로그를 보는데 어려움이 생김
- SQL 로깅 설정을 DEBUG로 적용 및 descriptor.sql에 trace 정책 적용시 쿼리 내용 출력 확인

> 3. application.propertes에 hiberate 관련 기본 설정 적용
- 특이사항 없음

> 4. 테스트를 위한 `schema.sql`, `data.sql` 작성 
- 프로젝트 실행시 product 테이블 생성을 위한 `schema.sql` 작성
- 프로젝트 실행시 product를 이용하는 로직 테스트를 위해 테스트용 더미 데이터 삽입하는 `data.sql` 작성

## c. 작업 회고
> 1. 가장 쉽게 요구사항을 충족할 수 있는 방법
`테스트에 드는 공수를 줄이는 것`이 [#31] 이슈의 핵심 요지라고 생각했다. 이를 해결하기 위해 `테스트 코드를 이용한 테스트 자동화`등을 찾아봤는데 API TEST가 가장 간단히 문제를 해결하는 방법이라고 판단되서 더미 데이터 삽입을 위한 방법들을 고민했다. 추가로 Config 클래스를 이용해 이런 과정을 스프링이 뜰 때 처리하는 방법들도 확인했는데 이번에 적용한 `application.properties`가 사용할 수 있는 공수로 원하는 바를 이룰 수 있다고 판단해 채택했다.

## d. 기타 사항
> `테스트 코드를 잘 활용하면 이런 과정이 애초에 필요 없을 수도 있지 않을까?` 라는 궁금증이 생겼는데 이는 나중에 고민해보기로 했다. 이번 작업에 대한 테스트는 h2 콘솔에 직접 접근해 각 작업의 결과를 확인했다.
